### PR TITLE
Game UI cleanup

### DIFF
--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -32,9 +32,9 @@ type GameQuadrantProps = {
 const GameQuadrant: Component<GameQuadrantProps> = (props) => {
   return (
     <div
-      class={`flex flex-col flex-auto ${
-        props.gameX === 0 ? "mr-[4px]" : "ml-[4px]"
-      } ${props.gameY === 0 ? "mb-[4px]" : "mt-[4px]"}`}
+      class={`quordle-board flex flex-col flex-auto ${
+        props.gameX === 0 ? "mr-[1px]" : "ml-[1px]"
+      } ${props.gameY === 0 ? "mb-[1px]" : "mt-[1px]"}`}
     >
       {GAME_ROWS_ARR.map((rowIndex) => (
         <div class="flex w-full">
@@ -113,7 +113,7 @@ const Game: Component<GameProps> = (props) => {
         )}
       </div>
       <div
-        class="max-w-[550px] m-auto w-full flex-auto"
+        class="max-w-[550px] m-auto w-full flex-auto quordle-board-group"
         classList={{
           "overflow-hidden": tutorialOpen() || statisticsOpen(),
           "overflow-auto": !(tutorialOpen() || statisticsOpen()),

--- a/src/Keyboard.tsx
+++ b/src/Keyboard.tsx
@@ -87,12 +87,11 @@ const Key: Component<KeyProps> = (props) => {
 
   return (
     <button
-      class="quordle-box quordle-key w-[10%]"
+      class="quordle-key w-[10%]"
       classList={{
-        "border-l-[1px]": props.x === 0,
-        "border-t-[1px]": props.y === 0,
-        "border-b-transparent": props.key === "enter3",
-        "border-r-transparent": props.key === "enter1",
+        "quordle-enter-top": props.key === "enter3",
+        "quordle-enter": props.key === "enter2",
+        "quordle-enter-left": props.key === "enter1",
       }}
       style={keyStyle()}
       onClick={() => {
@@ -135,7 +134,7 @@ type KeyboardProps = {
 };
 const Keyboard: Component<KeyboardProps> = (props) => {
   return (
-    <div class="w-full flex-col">
+    <div class="w-full flex-col quordle-keyboard">
       {KEYBOARD_KEYS.map((row, y) => (
         <div class="flex w-full">
           {row.map((key, x) => (

--- a/src/index.css
+++ b/src/index.css
@@ -40,3 +40,13 @@ code {
     @apply absolute left-0 top-0 bottom-0 right-0 flex items-center justify-center;
   }
 }
+
+/*Make the scrollbar less awk on desktop*/
+@media(min-width: 1024px) {
+  .quordle-board-group::-webkit-scrollbar {
+    width: 1px;
+  }
+  .quordle-board-group::-webkit-scrollbar-thumb {
+    background-color: #fff;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,11 @@ code {
   .quordle-box {
     @apply text-white bg-gray-900 m-1 rounded p-0 aspect-square relative select-none;
   }
+  .quordle-box-present {
+    @apply bg-gray-600;
+  }
+  .quordle-box-past {
+    @apply bg-gray-700;
   }
   .quordle-box-content {
     @apply absolute left-0 top-0 bottom-0 right-0 flex items-center justify-center;

--- a/src/index.css
+++ b/src/index.css
@@ -34,11 +34,39 @@ code {
     @apply bg-gray-700 text-white hover:bg-gray-700 hover:text-white !important;
   }
   .quordle-box {
-    @apply text-white border-white border-r-[1px] border-b-[1px] p-0 aspect-square relative select-none;
+    @apply text-white bg-gray-900 m-1 rounded p-0 aspect-square relative select-none;
+  }
   }
   .quordle-box-content {
     @apply absolute left-0 top-0 bottom-0 right-0 flex items-center justify-center;
   }
+  .quordle-board {
+    @apply pr-1 first:pl-1 pt-1 pb-1;
+  }
+  .quordle-keyboard {
+    @apply pb-1;
+  }
+  .quordle-key {
+    @apply text-white bg-zinc-600 ml-1 mt-1 last:mr-1 rounded-sm p-0 aspect-square relative select-none;
+  }
+  .quordle-enter-top {
+    @apply rounded-b-none;
+  }
+  .quordle-enter-left {
+    @apply rounded-r-none;
+  }
+  .quordle-enter {
+    @apply ml-0 mt-0 rounded-t-none rounded-l-none;
+  }
+}
+
+.quordle-enter-left {
+  width: calc(10% + 0.25rem);
+}
+
+.quordle-enter-top {
+  height: calc(10% + 0.25rem);
+}
 
 /* manual font alignment */
 .quordle-box-content {

--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,10 @@ code {
   .quordle-box-content {
     @apply absolute left-0 top-0 bottom-0 right-0 flex items-center justify-center;
   }
+
+/* manual font alignment */
+.quordle-box-content {
+  top: -2px;
 }
 
 /*Make the scrollbar less awk on desktop*/


### PR DESCRIPTION
Makes the Quordle game UI prettier and hopefully a bit more readable. A few improvements:

* The text wasn't perfectly vertically aligned, despite having vertical alignment CSS; probably something to do with the font? I manually fixed it with a `top: -2px`.
* Uses margin and color, rather than a grid of borders, to differentiate boxes from each other and to differentiate different Quordle boards from each other. I think margin feels a bit friendlier than a lined grid; the color tweaks add some visual clarity when the game board hits the keyboard at the bottom of the screen, since previously the boxes and the keyboard buttons were visually identical. The old setup also felt a bit cramped on mobile, since there was no margin when the boards hit the edge of the screen.
* Highlights the current active row to guess, and dims future guesses (as well as guesses that will never happen, e.g. rows that are after you've already guessed the answer for the given board).
* Makes the scrollbar take up less space on desktop (Webkit only).

Some side-by-side screenshots:

## Desktop, no guesses:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/803092/153650189-47066db3-9721-4176-9f6f-709e28138de2.png">
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/803092/153650211-ebfc764b-9987-4712-a551-b0ddef961ce4.png">

## Desktop, some guesses + a win
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/803092/153650315-0b26df44-8ea2-4e34-8edf-6b43a324b137.png">
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/803092/153650346-a5cfdc2d-84a5-42de-b408-b05b8f9692bf.png">

## Mobile
![dev quordle com_ (1)](https://user-images.githubusercontent.com/803092/153650478-2a09b551-2e5a-44ee-bebb-98b4742ef4f1.png)
![localhost_3000_ (1)](https://user-images.githubusercontent.com/803092/153650488-b6555f33-eddf-4bd6-a5be-6095896f4ab1.png)
