### PR TITLE
Fancy cursors and nicer padding

### DIFF
--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -31,7 +31,7 @@ type GameQuadrantProps = {
 };
 const GameQuadrant: Component<GameQuadrantProps> = (props) => {
   return (
-    <div class="flex flex-col flex-auto first:pl-2 last:pr-2 first:pr-0.5 last:pl-0.5">
+    <div class="flex flex-col flex-auto first:pl-1.5 last:pr-1.5 first:pr-0.5 last:pl-0.5">
       {GAME_ROWS_ARR.map((rowIndex) => (
         <div class="flex w-full">
           {GAME_COLS_ARR.map((colIndex) => (
@@ -121,7 +121,7 @@ const Game: Component<GameProps> = (props) => {
       >
         <div class="w-full flex-col">
           {NUM_GAMES_Y_ARR.map((gameY) => (
-            <div class="flex w-full pt-0.5 last:pb-0.5">
+            <div class="flex w-full pt-1 last:pb-1">
               {NUM_GAMES_X_ARR.map((gameX) => (
                 <GameQuadrant mode={props.mode} gameX={gameX} gameY={gameY} />
               ))}

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -31,7 +31,7 @@ type GameQuadrantProps = {
 };
 const GameQuadrant: Component<GameQuadrantProps> = (props) => {
   return (
-    <div class="flex flex-col flex-auto p-1">
+    <div class="flex flex-col flex-auto first:pl-2 last:pr-2 first:pr-0.5 last:pl-0.5">
       {GAME_ROWS_ARR.map((rowIndex) => (
         <div class="flex w-full">
           {GAME_COLS_ARR.map((colIndex) => (
@@ -121,7 +121,7 @@ const Game: Component<GameProps> = (props) => {
       >
         <div class="w-full flex-col">
           {NUM_GAMES_Y_ARR.map((gameY) => (
-            <div class="flex w-full">
+            <div class="flex w-full pt-0.5 last:pb-0.5">
               {NUM_GAMES_X_ARR.map((gameX) => (
                 <GameQuadrant mode={props.mode} gameX={gameX} gameY={gameY} />
               ))}

--- a/src/GameTile.tsx
+++ b/src/GameTile.tsx
@@ -12,6 +12,7 @@ type GameTileRendererProps = {
   state: GameTileState;
   letter: string;
   rowTemporalState: TemporalState;
+  activeCol: number;
 };
 export const GameTileRenderer: Component<GameTileRendererProps> = (props) => {
   return (
@@ -29,6 +30,7 @@ export const GameTileRenderer: Component<GameTileRendererProps> = (props) => {
         "text-black": props.state === "correct" || props.state === "diff",
         "text-rose-600": props.state === "invalid",
         "text-black dark:text-white": props.state === "none",
+        "quordle-heartbeat-anim": props.activeCol === props.gameCol && props.rowTemporalState === 'present',
       }}
     >
       <div class="quordle-box-content" textContent={props.letter} />
@@ -47,6 +49,12 @@ const GameTile: Component<GameTileProps> = (props) => {
   const gameIndex = props.gameX + props.gameY * NUM_GAMES_X;
 
   const [gamesData] = useGamesDataContext();
+
+  const activeCol = createMemo((): number => {
+    const gameData = gamesData[props.mode];
+    const current = gameData.current;
+    return current.length;
+  });
 
   const shouldRenderLetter = createMemo(() => {
     const gameData = gamesData[props.mode];
@@ -119,6 +127,7 @@ const GameTile: Component<GameTileProps> = (props) => {
       gameRow={props.gameRow}
       gameCol={props.gameCol}
       rowTemporalState={temporalState()}
+      activeCol={activeCol()}
     />
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -25,7 +25,7 @@ code {
 
 @keyframes color-fade {
   from {
-    background-color: #fff;
+    background-color: #ddd;
   }
   to {
     background-color: #bbb;

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,15 @@ code {
   background-repeat: no-repeat;
 }
 
+@keyframes color-fade {
+  from {
+    background-color: #fff;
+  }
+  to {
+    background-color: #bbb;
+  }
+}
+
 @layer components {
   body {
     @apply bg-white dark:bg-gray-800;
@@ -50,4 +59,11 @@ code {
       @apply bg-gray-500;
     }
   }
+}
+
+.quordle-heartbeat-anim {
+  animation-name: color-fade;
+  animation-duration: 600ms;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
 }


### PR DESCRIPTION
Even after #1, I still wasn't 100% satisfied with the game board padding — the center had too much spacing, and contrasted awkwardly with the sides. It would be nice to get things a little more even-looking, but the problem was that making them closer together lost a little visual clarity of which board was which.

To get around that, this PR introduces a new, fancy animated cursor! We add an animated heartbeat-like fade on the box that's currently "active" — that is, the box that will get a letter when you type one in — and that helps differentiate the boards quite a bit, meaning we can remove some of the awkwardly-large padding. There's still a bit of extra padding between the boards, but not too much.

Here's what the animation looks like:
![quordle-cursor](https://user-images.githubusercontent.com/803092/153733682-47b5102d-9fb7-4763-9c14-538dc5bf717b.gif)


And here's a side by side comparison:
## New

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/803092/153733604-a85c6830-c98b-4ed0-8a56-639e167bc7d8.png">

## Old
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/803092/153733608-ee5a10ed-2a18-49a1-9a6e-304c7bde3fb7.png">


